### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:vivid
 MAINTAINER Fabian M. Borschel <fabian.borschel@commercetools.de>
 
 ENV PIO_VERSION 0.9.4
@@ -8,10 +8,9 @@ ENV HBASE_VERSION 1.0.0
 
 ENV PIO_HOME /PredictionIO-${PIO_VERSION}
 ENV PATH=${PIO_HOME}/bin:$PATH
-ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
-RUN apt-get update && apt-get install -y curl openjdk-7-jdk libgfortran3 python-pip
-RUN pip install predictionio
+RUN apt-get update && apt-get install -y curl openjdk-8-jdk libgfortran3
 
 RUN curl -O https://d8k1yxp8elc6b.cloudfront.net/PredictionIO-${PIO_VERSION}.tar.gz
 RUN tar -xvzf PredictionIO-${PIO_VERSION}.tar.gz -C / && mkdir -p ${PIO_HOME}/vendors


### PR DESCRIPTION
using ubuntu vivid
using package openjdk-8-jdk (available from ubuntu vivid on)
removed python support for PredictionIO (not needed anymore)
