### PR TITLE
Update PredictionIO version to 0.9.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,3 @@ RUN sed -i "s|VAR_PIO_HOME|${PIO_HOME}|" ${PIO_HOME}/vendors/hbase-${HBASE_VERSI
 
 #triggers fetching the complete sbt environment
 RUN ${PIO_HOME}/sbt/sbt -batch
-
-# clean
-RUN apt-get remove -y python-pip curl \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean autoclean \
-    && apt-get autoremove -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu
 MAINTAINER Fabian M. Borschel <fabian.borschel@commercetools.de>
 
-ENV PIO_VERSION 0.9.4
-ENV SPARK_VERSION 1.4.1
+ENV PIO_VERSION 0.9.5
+ENV SPARK_VERSION 1.5.1
 ENV ELASTICSEARCH_VERSION 1.4.4
 ENV HBASE_VERSION 1.0.0
 
@@ -10,30 +10,37 @@ ENV PIO_HOME /PredictionIO-${PIO_VERSION}
 ENV PATH=${PIO_HOME}/bin:$PATH
 ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
 
-RUN apt-get update && apt-get install -y curl openjdk-7-jdk libgfortran3 python-pip
-RUN pip install predictionio
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl openjdk-7-jdk libgfortran3 python-pip \
+    && pip install predictionio
 
-RUN curl -O https://d8k1yxp8elc6b.cloudfront.net/PredictionIO-${PIO_VERSION}.tar.gz
-RUN tar -xvzf PredictionIO-${PIO_VERSION}.tar.gz -C / && mkdir -p ${PIO_HOME}/vendors
-RUN rm PredictionIO-${PIO_VERSION}.tar.gz
-ADD files/pio-env.sh ${PIO_HOME}/conf/pio-env.sh
+RUN curl -O https://d8k1yxp8elc6b.cloudfront.net/PredictionIO-${PIO_VERSION}.tar.gz \
+    && tar -xvzf PredictionIO-${PIO_VERSION}.tar.gz -C / && mkdir -p ${PIO_HOME}/vendors \
+    && rm PredictionIO-${PIO_VERSION}.tar.gz
+COPY files/pio-env.sh ${PIO_HOME}/conf/pio-env.sh
 
-RUN curl -O http://d3kbcqa49mib13.cloudfront.net/spark-${SPARK_VERSION}-bin-hadoop2.6.tgz
-RUN tar -xvzf spark-${SPARK_VERSION}-bin-hadoop2.6.tgz -C ${PIO_HOME}/vendors
-RUN rm spark-${SPARK_VERSION}-bin-hadoop2.6.tgz
+RUN curl -O http://d3kbcqa49mib13.cloudfront.net/spark-${SPARK_VERSION}-bin-hadoop2.6.tgz \
+    && tar -xvzf spark-${SPARK_VERSION}-bin-hadoop2.6.tgz -C ${PIO_HOME}/vendors \
+    && rm spark-${SPARK_VERSION}-bin-hadoop2.6.tgz
 
-RUN curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz
-RUN tar -xvzf elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz -C ${PIO_HOME}/vendors
-RUN rm elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz
-RUN echo 'cluster.name: predictionio' >> ${PIO_HOME}/vendors/elasticsearch-${ELASTICSEARCH_VERSION}/config/elasticsearch.yml
-RUN echo 'network.host: 127.0.0.1' >> ${PIO_HOME}/vendors/elasticsearch-${ELASTICSEARCH_VERSION}/config/elasticsearch.yml
+RUN curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz \
+    && tar -xvzf elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz -C ${PIO_HOME}/vendors \
+    && rm elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz \
+    && echo 'cluster.name: predictionio' >> ${PIO_HOME}/vendors/elasticsearch-${ELASTICSEARCH_VERSION}/config/elasticsearch.yml \
+    && echo 'network.host: 127.0.0.1' >> ${PIO_HOME}/vendors/elasticsearch-${ELASTICSEARCH_VERSION}/config/elasticsearch.yml
 
-RUN curl -O http://archive.apache.org/dist/hbase/hbase-${HBASE_VERSION}/hbase-${HBASE_VERSION}-bin.tar.gz
-RUN tar -xvzf hbase-${HBASE_VERSION}-bin.tar.gz -C ${PIO_HOME}/vendors
-RUN rm hbase-${HBASE_VERSION}-bin.tar.gz
-ADD files/hbase-site.xml ${PIO_HOME}/vendors/hbase-${HBASE_VERSION}/conf/hbase-site.xml
-RUN sed -i "s|VAR_PIO_HOME|${PIO_HOME}|" ${PIO_HOME}/vendors/hbase-${HBASE_VERSION}/conf/hbase-site.xml
-RUN sed -i "s|VAR_HBASE_VERSION|${HBASE_VERSION}|" ${PIO_HOME}/vendors/hbase-${HBASE_VERSION}/conf/hbase-site.xml
+RUN curl -O http://archive.apache.org/dist/hbase/hbase-${HBASE_VERSION}/hbase-${HBASE_VERSION}-bin.tar.gz \
+    && tar -xvzf hbase-${HBASE_VERSION}-bin.tar.gz -C ${PIO_HOME}/vendors \
+    && rm hbase-${HBASE_VERSION}-bin.tar.gz
+COPY files/hbase-site.xml ${PIO_HOME}/vendors/hbase-${HBASE_VERSION}/conf/hbase-site.xml
+RUN sed -i "s|VAR_PIO_HOME|${PIO_HOME}|" ${PIO_HOME}/vendors/hbase-${HBASE_VERSION}/conf/hbase-site.xml \
+    && sed -i "s|VAR_HBASE_VERSION|${HBASE_VERSION}|" ${PIO_HOME}/vendors/hbase-${HBASE_VERSION}/conf/hbase-site.xml
 
 #triggers fetching the complete sbt environment
 RUN ${PIO_HOME}/sbt/sbt -batch
+
+# clean
+RUN apt-get remove -y python-pip curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean autoclean \
+    && apt-get autoremove -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,10 @@ ENV PATH=${PIO_HOME}/bin:$PATH
 ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl openjdk-7-jdk libgfortran3 python-pip \
-    && pip install predictionio
+    && apt-get install -y --auto-remove --no-install-recommends curl openjdk-7-jdk libgfortran3 python-pip \
+    && pip install predictionio \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN curl -O https://d8k1yxp8elc6b.cloudfront.net/PredictionIO-${PIO_VERSION}.tar.gz \
     && tar -xvzf PredictionIO-${PIO_VERSION}.tar.gz -C / && mkdir -p ${PIO_HOME}/vendors \


### PR DESCRIPTION
-  Update PredictionIO version to 0.9.5
- Reduce Image size from 2 GB to 1.3GB by group commands to one layer and using `--no-install-recommends` option for apt-get
